### PR TITLE
remove go version

### DIFF
--- a/tasks/build.sh
+++ b/tasks/build.sh
@@ -30,7 +30,6 @@ applications:
   buildpack: go_buildpack
   command: s3-broker --config ./config.yml --port \$PORT
 env:
-  GOVERSION: go1.12
   GOPACKAGENAME: github.com/cloudfoundry-community/s3-broker
 EOF
 


### PR DESCRIPTION
## Changes proposed in this pull request:

Remove the go version from the manifest.

## security considerations

none
