### PR TITLE
fix golang version so pipeline works

### DIFF
--- a/tasks/test.yml
+++ b/tasks/test.yml
@@ -5,7 +5,7 @@ image_resource:
   type: docker-image
   source:
     repository: golang
-    tag: "1.12"
+    tag: "1.14"
 
 inputs:
 - name: broker-src


### PR DESCRIPTION
## Changes proposed in this pull request:
- Fix the golang version so the pipeline works. We're using `http.Transport::Clone` which wasn't added until go 1.14
 
## security considerations
None