### PR TITLE
Pipeline updates

### DIFF
--- a/pipeline.yml
+++ b/pipeline.yml
@@ -1,6 +1,6 @@
 ---
 development-cf-creds: &development-cf-creds
-  CF_API_URL: ((development-cf-api-url))
+  CF_API_URL: ((dev-cf-api-url))
   CF_USERNAME: ((development-cf-username))
   CF_PASSWORD: ((development-cf-password))
   CF_ORGANIZATION: ((development-cf-organization))
@@ -14,7 +14,7 @@ staging-cf-creds: &staging-cf-creds
   CF_SPACE: ((staging-cf-space))
 
 production-cf-creds: &production-cf-creds
-  CF_API_URL: ((production-cf-api-url))
+  CF_API_URL: ((prod-cf-api-url))
   CF_USERNAME: ((production-cf-username))
   CF_PASSWORD: ((production-cf-password))
   CF_ORGANIZATION: ((production-cf-organization))
@@ -28,7 +28,7 @@ staging-cf-creds: &federalist-staging-cf-creds
   CF_SPACE: ((federalist-staging-cf-space))
 
 production-cf-creds: &federalist-production-cf-creds
-  CF_API_URL: ((production-cf-api-url))
+  CF_API_URL: ((prod-cf-api-url))
   CF_USERNAME: ((production-cf-username))
   CF_PASSWORD: ((production-cf-password))
   CF_ORGANIZATION: ((federalist-production-cf-organization))
@@ -83,7 +83,7 @@ jobs:
       POLICY_PREFIX: ((development-policy-prefix))
       BUCKET_PREFIX: ((development-bucket-prefix))
       IAM_PATH: ((development-iam-path))
-      CF_API_URL: ((development-cf-api-url))
+      CF_API_URL: ((dev-cf-api-url))
       CF_CLIENT_ID: ((development-cf-client-id))
       CF_CLIENT_SECRET: ((development-cf-client-secret))
       CONFIG_FILE_NAME: base-config-template
@@ -141,8 +141,6 @@ jobs:
       trigger: true
     - get: broker-config-dev
       passed: [push-s3-broker-development]
-      trigger: true
-    - get: terraform-yaml-development
       trigger: true
     - get: cf-development-version
       trigger: true
@@ -333,8 +331,6 @@ jobs:
     - get: broker-config
       passed: [push-s3-broker-staging]
       trigger: true
-    - get: terraform-yaml-staging
-      trigger: true
     - get: cf-staging-version
       trigger: true
     - get: general-task
@@ -393,8 +389,6 @@ jobs:
       trigger: true
     - get: broker-config
       passed: [push-federalist-s3-broker-staging]
-      trigger: true
-    - get: terraform-yaml-staging
       trigger: true
     - get: cf-staging-version
       trigger: true
@@ -457,7 +451,7 @@ jobs:
       POLICY_PREFIX: ((production-policy-prefix))
       BUCKET_PREFIX: ((production-bucket-prefix))
       IAM_PATH: ((production-iam-path))
-      CF_API_URL: ((production-cf-api-url))
+      CF_API_URL: ((prod-cf-api-url))
       CF_CLIENT_ID: ((production-cf-client-id))
       CF_CLIENT_SECRET: ((production-cf-client-secret))
       CONFIG_FILE_NAME: base-config-template
@@ -526,7 +520,7 @@ jobs:
       BUCKET_PREFIX: ((federalist-production-bucket-prefix))
       INTERNAL_VPCE_ID: ((production-s3-vpce_id))
       IAM_PATH: ((federalist-production-iam-path))
-      CF_API_URL: ((production-cf-api-url))
+      CF_API_URL: ((prod-cf-api-url))
       CF_CLIENT_ID: ((production-cf-client-id))
       CF_CLIENT_SECRET: ((production-cf-client-secret))
       CONFIG_FILE_NAME: federalist-config-template
@@ -587,7 +581,7 @@ jobs:
       BUCKET_PREFIX: ((federalist-production-bucket-prefix))
       INTERNAL_VPCE_ID: ((production-s3-vpce_id))
       IAM_PATH: ((federalist-production-iam-path))
-      CF_API_URL: ((production-cf-api-url))
+      CF_API_URL: ((prod-cf-api-url))
       CF_CLIENT_ID: ((production-cf-client-id))
       CF_CLIENT_SECRET: ((production-cf-client-secret))
       CONFIG_FILE_NAME: pages-config-template
@@ -634,8 +628,6 @@ jobs:
       trigger: true
     - get: broker-config
       passed: [push-s3-broker-production]
-      trigger: true
-    - get: terraform-yaml-production
       trigger: true
     - get: cf-production-version
       trigger: true
@@ -686,8 +678,6 @@ jobs:
     - get: broker-config
       passed: [push-federalist-s3-broker-production]
       trigger: true
-    - get: terraform-yaml-production
-      trigger: true
     - get: cf-production-version
       trigger: true
     - get: general-task
@@ -735,8 +725,6 @@ jobs:
       trigger: true
     - get: broker-config
       passed: [push-pages-s3-broker-production]
-      trigger: true
-    - get: terraform-yaml-production
       trigger: true
     - get: cf-production-version
       trigger: true
@@ -824,42 +812,42 @@ resources:
 - name: broker-src
   type: git
   source:
-    uri: ((s3-broker-app-url))
-    branch: ((s3-broker-app-branch))
+    uri: https://github.com/cloud-gov/s3-broker
+    branch: main
     commit_verification_keys: ((cloud-gov-pgp-keys))
 
 - name: broker-src-dev
   type: git
   source:
-    uri: ((s3-broker-app-url))
-    branch: ((s3-broker-app-branch-dev))
+    uri: https://github.com/cloud-gov/s3-broker
+    branch: main
     commit_verification_keys: ((cloud-gov-pgp-keys))
 
 - name: broker-config
   type: git
   source:
-    uri: ((s3-broker-config-url))
-    branch: ((s3-broker-config-branch))
+    uri: https://github.com/cloud-gov/cg-deploy-s3-broker
+    branch: main
     commit_verification_keys: ((cloud-gov-pgp-keys))
 
 - name: broker-config-dev
   type: git
   source:
-    uri: ((s3-broker-config-url))
-    branch: ((s3-broker-config-branch-dev))
+    uri: https://github.com/cloud-gov/cg-deploy-s3-broker
+    branch: main
     commit_verification_keys: ((cloud-gov-pgp-keys))
 
 - name: pipeline-tasks
   type: git
   source:
-    uri: ((pipeline-tasks-git-url))
-    branch: ((pipeline-tasks-git-branch))
+    uri: https://github.com/cloud-gov/cg-pipeline-tasks
+    branch: main
     commit_verification_keys: ((cloud-gov-pgp-keys))
 
 - name: deploy-s3-broker-app-development
   type: cf
   source:
-    api: ((development-cf-api-url))
+    api: ((dev-cf-api-url))
     username: ((development-cf-username))
     password: ((development-cf-password))
     organization: ((development-cf-organization))
@@ -886,7 +874,7 @@ resources:
 - name: deploy-s3-broker-app-production
   type: cf
   source:
-    api: ((production-cf-api-url))
+    api: ((prod-cf-api-url))
     username: ((production-cf-username))
     password: ((production-cf-password))
     organization: ((production-cf-organization))
@@ -895,7 +883,7 @@ resources:
 - name: deploy-federalist-s3-broker-app-production
   type: cf
   source:
-    api: ((production-cf-api-url))
+    api: ((prod-cf-api-url))
     username: ((production-cf-username))
     password: ((production-cf-password))
     organization: ((production-cf-organization))
@@ -904,7 +892,7 @@ resources:
 - name: deploy-pages-s3-broker-app-production
   type: cf
   source:
-    api: ((production-cf-api-url))
+    api: ((prod-cf-api-url))
     username: ((production-cf-username))
     password: ((production-cf-password))
     organization: ((production-cf-organization))
@@ -933,27 +921,6 @@ resources:
     driver: ((production-semver-driver))
     key: ((production-semver-key))
     region_name: ((production-semver-region))
-
-- name: terraform-yaml-development
-  type: s3-iam
-  source:
-    bucket: ((development-terraform-bucket))
-    region_name: ((development-terraform-region))
-    versioned_file: ((development-terraform-file))
-
-- name: terraform-yaml-staging
-  type: s3-iam
-  source:
-    bucket: ((staging-terraform-bucket))
-    region_name: ((staging-terraform-region))
-    versioned_file: ((staging-terraform-file))
-
-- name: terraform-yaml-production
-  type: s3-iam
-  source:
-    bucket: ((production-terraform-bucket))
-    region_name: ((production-terraform-region))
-    versioned_file: ((production-terraform-file))
 
 - name: slack
   type: slack-notification

--- a/pipeline.yml
+++ b/pipeline.yml
@@ -142,8 +142,6 @@ jobs:
     - get: broker-config-dev
       passed: [push-s3-broker-development]
       trigger: true
-    - get: cf-development-version
-      trigger: true
     - get: general-task
   - in_parallel:
     - task: acceptance-tests
@@ -331,8 +329,6 @@ jobs:
     - get: broker-config
       passed: [push-s3-broker-staging]
       trigger: true
-    - get: cf-staging-version
-      trigger: true
     - get: general-task
   - in_parallel:
     - task: acceptance-tests
@@ -389,8 +385,6 @@ jobs:
       trigger: true
     - get: broker-config
       passed: [push-federalist-s3-broker-staging]
-      trigger: true
-    - get: cf-staging-version
       trigger: true
     - get: general-task
   - in_parallel:
@@ -629,8 +623,6 @@ jobs:
     - get: broker-config
       passed: [push-s3-broker-production]
       trigger: true
-    - get: cf-production-version
-      trigger: true
     - get: general-task
   - in_parallel:
     - task: acceptance-tests
@@ -678,8 +670,6 @@ jobs:
     - get: broker-config
       passed: [push-federalist-s3-broker-production]
       trigger: true
-    - get: cf-production-version
-      trigger: true
     - get: general-task
   - in_parallel:
     - task: acceptance-tests
@@ -725,8 +715,6 @@ jobs:
       trigger: true
     - get: broker-config
       passed: [push-pages-s3-broker-production]
-      trigger: true
-    - get: cf-production-version
       trigger: true
     - get: general-task
   - in_parallel:
@@ -897,30 +885,6 @@ resources:
     password: ((production-cf-password))
     organization: ((production-cf-organization))
     space: ((production-cf-space))
-    
-- name: cf-development-version
-  type: semver-iam
-  source:
-    bucket: ((development-semver-bucket))
-    driver: ((development-semver-driver))
-    key: ((development-semver-key))
-    region_name: ((development-semver-region))
-
-- name: cf-staging-version
-  type: semver-iam
-  source:
-    bucket: ((staging-semver-bucket))
-    driver: ((staging-semver-driver))
-    key: ((staging-semver-key))
-    region_name: ((staging-semver-region))
-
-- name: cf-production-version
-  type: semver-iam
-  source:
-    bucket: ((production-semver-bucket))
-    driver: ((production-semver-driver))
-    key: ((production-semver-key))
-    region_name: ((production-semver-region))
 
 - name: slack
   type: slack-notification

--- a/pipeline.yml
+++ b/pipeline.yml
@@ -43,6 +43,7 @@ jobs:
     - get: broker-config
       trigger: true
   - task: test
+    image: general-task
     file: broker-config/tasks/test.yml
 
 - name: test-s3-broker-dev
@@ -53,6 +54,7 @@ jobs:
     - get: broker-config-dev
       trigger: true
   - task: test
+    image: general-task
     file: broker-config-dev/tasks/test-dev.yml
 
 - name: push-s3-broker-development
@@ -67,6 +69,7 @@ jobs:
       trigger: true
     - get: pipeline-tasks
   - task: build
+    image: general-task
     file: broker-config-dev/tasks/build-dev.yml
     params:
       AUTH_USERNAME: ((development-auth-name))
@@ -195,6 +198,7 @@ jobs:
       trigger: true
     - get: pipeline-tasks
   - task: build
+    image: general-task
     file: broker-config/tasks/build.yml
     params:
       AUTH_USERNAME: ((staging-auth-name))
@@ -262,6 +266,7 @@ jobs:
       trigger: true
     - get: pipeline-tasks
   - task: build
+    image: general-task
     file: broker-config/tasks/build.yml
     params:
       AUTH_USERNAME: ((staging-auth-name))
@@ -326,6 +331,7 @@ jobs:
       trigger: true
   - in_parallel:
     - task: acceptance-tests
+      image: general-task
       file: broker-config/tasks/acceptance-tests.yml
       params:
         <<: *staging-cf-creds
@@ -346,6 +352,7 @@ jobs:
             ]
           }
     - task: acceptance-tests-public
+      image: general-task
       file: broker-config/tasks/acceptance-tests.yml
       params:
         <<: *staging-cf-creds
@@ -356,6 +363,7 @@ jobs:
         IS_PUBLIC: "true"
         ENCRYPTION: *encryption
     - task: acceptance-tests-public-delete
+      image: general-task
       file: broker-config/tasks/acceptance-tests.yml
       params:
         <<: *staging-cf-creds
@@ -383,6 +391,7 @@ jobs:
       trigger: true
   - in_parallel:
     - task: federalist-acceptance-tests
+      image: general-task
       file: broker-config/tasks/acceptance-tests.yml
       params:
         <<: *federalist-staging-cf-creds
@@ -403,6 +412,7 @@ jobs:
             ]
           }
     - task: federalist-acceptance-tests-public
+      image: general-task
       file: broker-config/tasks/acceptance-tests.yml
       params:
         <<: *federalist-staging-cf-creds
@@ -425,6 +435,7 @@ jobs:
       trigger: true
     - get: pipeline-tasks
   - task: build
+    image: general-task
     file: broker-config/tasks/build.yml
     params:
       AUTH_USERNAME: ((production-auth-name))
@@ -491,6 +502,7 @@ jobs:
       trigger: true
     - get: pipeline-tasks
   - task: build
+    image: general-task
     file: broker-config/tasks/build.yml
     params:
       AUTH_USERNAME: ((production-auth-name))
@@ -551,6 +563,7 @@ jobs:
       trigger: true
     - get: pipeline-tasks
   - task: build
+    image: general-task
     file: broker-config/tasks/build.yml
     params:
       AUTH_USERNAME: ((production-auth-name))
@@ -616,6 +629,7 @@ jobs:
       trigger: true
   - in_parallel:
     - task: acceptance-tests
+      image: general-task
       file: broker-config/tasks/acceptance-tests.yml
       params:
         <<: *production-cf-creds
@@ -626,6 +640,7 @@ jobs:
         IS_PUBLIC: "false"
         ENCRYPTION: *encryption
     - task: acceptance-tests-public
+      image: general-task
       file: broker-config/tasks/acceptance-tests.yml
       params:
         <<: *production-cf-creds
@@ -636,6 +651,7 @@ jobs:
         IS_PUBLIC: "true"
         ENCRYPTION: *encryption
     - task: acceptance-tests-public-delete
+      image: general-task
       file: broker-config/tasks/acceptance-tests.yml
       params:
         <<: *production-cf-creds
@@ -663,6 +679,7 @@ jobs:
       trigger: true
   - in_parallel:
     - task: acceptance-tests
+      image: general-task
       file: broker-config/tasks/acceptance-tests.yml
       params:
         <<: *federalist-production-cf-creds
@@ -673,6 +690,7 @@ jobs:
         IS_PUBLIC: "false"
         ENCRYPTION: *encryption
     - task: acceptance-tests-public
+      image: general-task
       file: broker-config/tasks/acceptance-tests.yml
       params:
         <<: *federalist-production-cf-creds
@@ -683,6 +701,7 @@ jobs:
         IS_PUBLIC: "true"
         ENCRYPTION: *encryption
     - task: acceptance-tests-vpc
+      image: general-task
       file: broker-config/tasks/acceptance-tests.yml
       params:
         <<: *federalist-production-cf-creds
@@ -709,6 +728,7 @@ jobs:
       trigger: true
   - in_parallel:
     - task: acceptance-tests
+      image: general-task
       file: broker-config/tasks/acceptance-tests.yml
       params:
         <<: *federalist-production-cf-creds
@@ -719,6 +739,7 @@ jobs:
         IS_PUBLIC: "false"
         ENCRYPTION: *encryption
     - task: acceptance-tests-vpc
+      image: general-task
       file: broker-config/tasks/acceptance-tests.yml
       params:
         <<: *federalist-production-cf-creds
@@ -923,3 +944,12 @@ resources:
   type: slack-notification
   source:
     url: ((slack-webhook-url))
+
+- name: general-task
+  type: registry-image
+  source:
+    aws_access_key_id: ((ecr_aws_key))
+    aws_secret_access_key: ((ecr_aws_secret))
+    repository: general-task
+    aws_region: us-gov-west-1
+    tag: latest

--- a/pipeline.yml
+++ b/pipeline.yml
@@ -42,6 +42,7 @@ jobs:
       trigger: true
     - get: broker-config
       trigger: true
+    - get: general-task
   - task: test
     image: general-task
     file: broker-config/tasks/test.yml
@@ -53,6 +54,7 @@ jobs:
       trigger: true
     - get: broker-config-dev
       trigger: true
+    - get: general-task
   - task: test
     image: general-task
     file: broker-config-dev/tasks/test-dev.yml
@@ -68,6 +70,7 @@ jobs:
       passed: [test-s3-broker-dev]
       trigger: true
     - get: pipeline-tasks
+    - get: general-task
   - task: build
     image: general-task
     file: broker-config-dev/tasks/build-dev.yml
@@ -143,6 +146,7 @@ jobs:
       trigger: true
     - get: cf-development-version
       trigger: true
+    - get: general-task
   - in_parallel:
     - task: acceptance-tests
       file: broker-config-dev/tasks/acceptance-tests-dev.yml
@@ -166,6 +170,7 @@ jobs:
           }
     - task: acceptance-tests-public
       file: broker-config-dev/tasks/acceptance-tests-dev.yml
+      image: general-task
       params:
         <<: *development-cf-creds
         APP_NAME: s3-acceptance-test-public
@@ -176,6 +181,7 @@ jobs:
         ENCRYPTION: *encryption
     - task: acceptance-tests-public-delete
       file: broker-config-dev/tasks/acceptance-tests-dev.yml
+      image: general-task
       params:
         <<: *development-cf-creds
         APP_NAME: s3-acceptance-test-public-delete
@@ -197,6 +203,7 @@ jobs:
       passed: [test-s3-broker]
       trigger: true
     - get: pipeline-tasks
+    - get: general-task
   - task: build
     image: general-task
     file: broker-config/tasks/build.yml
@@ -265,6 +272,7 @@ jobs:
       passed: [test-s3-broker]
       trigger: true
     - get: pipeline-tasks
+    - get: general-task
   - task: build
     image: general-task
     file: broker-config/tasks/build.yml
@@ -329,6 +337,7 @@ jobs:
       trigger: true
     - get: cf-staging-version
       trigger: true
+    - get: general-task
   - in_parallel:
     - task: acceptance-tests
       image: general-task
@@ -389,6 +398,7 @@ jobs:
       trigger: true
     - get: cf-staging-version
       trigger: true
+    - get: general-task
   - in_parallel:
     - task: federalist-acceptance-tests
       image: general-task
@@ -434,6 +444,7 @@ jobs:
       passed: [acceptance-tests-staging]
       trigger: true
     - get: pipeline-tasks
+    - get: general-task
   - task: build
     image: general-task
     file: broker-config/tasks/build.yml
@@ -501,6 +512,7 @@ jobs:
       passed: [federalist-acceptance-tests-staging]
       trigger: true
     - get: pipeline-tasks
+    - get: general-task
   - task: build
     image: general-task
     file: broker-config/tasks/build.yml
@@ -627,6 +639,7 @@ jobs:
       trigger: true
     - get: cf-production-version
       trigger: true
+    - get: general-task
   - in_parallel:
     - task: acceptance-tests
       image: general-task
@@ -677,6 +690,7 @@ jobs:
       trigger: true
     - get: cf-production-version
       trigger: true
+    - get: general-task
   - in_parallel:
     - task: acceptance-tests
       image: general-task
@@ -726,6 +740,7 @@ jobs:
       trigger: true
     - get: cf-production-version
       trigger: true
+    - get: general-task
   - in_parallel:
     - task: acceptance-tests
       image: general-task

--- a/pipeline.yml
+++ b/pipeline.yml
@@ -35,17 +35,6 @@ production-cf-creds: &federalist-production-cf-creds
   CF_SPACE: ((federalist-production-cf-space))
 
 jobs:
-- name: test-s3-broker
-  plan:
-  - in_parallel:
-    - get: broker-src
-      trigger: true
-    - get: broker-config
-      trigger: true
-    - get: general-task
-  - task: test
-    image: general-task
-    file: broker-config/tasks/test.yml
 
 - name: test-s3-broker-dev
   plan:
@@ -187,6 +176,29 @@ jobs:
         IS_PUBLIC: "true"
         IS_DELETE: "true"
         ENCRYPTION: *encryption
+
+- name: set-self
+  plan:
+  - get: broker-config
+    trigger: true
+  - get: broker-src
+    trigger: true
+  - set_pipeline: self
+    file: broker-config/pipeline.yml
+
+- name: test-s3-broker
+  plan:
+  - in_parallel:
+    - get: broker-src
+      trigger: true
+      passed: [set-self]
+    - get: broker-config
+      trigger: true
+      passed: [set-self]
+    - get: general-task
+  - task: test
+    image: general-task
+    file: broker-config/tasks/test.yml
 
 - name: push-s3-broker-staging
   serial: true

--- a/tasks/acceptance-tests-dev.yml
+++ b/tasks/acceptance-tests-dev.yml
@@ -1,11 +1,6 @@
 ---
 platform: linux
 
-image_resource:
-  type: docker-image
-  source:
-    repository: 18fgsa/concourse-task
-
 inputs:
 - name: broker-src-dev
 

--- a/tasks/acceptance-tests.yml
+++ b/tasks/acceptance-tests.yml
@@ -1,11 +1,6 @@
 ---
 platform: linux
 
-image_resource:
-  type: docker-image
-  source:
-    repository: 18fgsa/concourse-task
-
 inputs:
 - name: broker-src
 

--- a/tasks/build-dev.yml
+++ b/tasks/build-dev.yml
@@ -1,11 +1,6 @@
 ---
 platform: linux
 
-image_resource:
-  type: docker-image
-  source:
-    repository: 18fgsa/concourse-task
-
 inputs:
 - name: broker-src-dev
 - name: broker-config-dev

--- a/tasks/build.yml
+++ b/tasks/build.yml
@@ -1,11 +1,6 @@
 ---
 platform: linux
 
-image_resource:
-  type: docker-image
-  source:
-    repository: 18fgsa/concourse-task
-
 inputs:
 - name: broker-src
 - name: broker-config

--- a/tasks/test.yml
+++ b/tasks/test.yml
@@ -1,12 +1,6 @@
 ---
 platform: linux
 
-image_resource:
-  type: docker-image
-  source:
-    repository: golang
-    tag: "1.20"
-
 inputs:
 - name: broker-src
   path: s3-broker


### PR DESCRIPTION
## Changes proposed in this pull request:

- Update pipeline to be self-flying
- Remove triggers based on Terraform state YAML. We don't necessarily need or want this broker to redeploy when Terraform for a given environment (e.g. development) is redeployed. There is no use of Terraform outputs in the pipeline or configuration of the broker
- Remove triggers based on defunct S3 bucket tracking the semver of deployed components
- Update pipeline to use latest hardened containers and general-task iamge

## security considerations

The main security facing change here is updating the pipeline to use the latest hardened containers including `general-task`
