### PR TITLE
update default log level to INFO

### DIFF
--- a/base-config-template.yml
+++ b/base-config-template.yml
@@ -1,4 +1,4 @@
-log_level: DEBUG
+log_level: INFO
 username: username
 password: password
 s3_config:

--- a/federalist-config-template.yml
+++ b/federalist-config-template.yml
@@ -1,4 +1,4 @@
-log_level: DEBUG
+log_level: INFO
 username: username
 password: password
 s3_config:

--- a/pages-config-template.yml
+++ b/pages-config-template.yml
@@ -1,4 +1,4 @@
-log_level: DEBUG
+log_level: INFO
 username: username
 password: password
 s3_config:


### PR DESCRIPTION
## Changes proposed in this pull request:

- update default log level to INFO to avoid unnecessary logs in prod 

## security considerations

Debug logs may inadvertently contain sensitive data, so changing the default log level to INFO makes it less likely for sensitive data to get logged to prod
